### PR TITLE
PT-9091: Created date in Content is not corresponding to the creation date

### DIFF
--- a/VirtoCommerce.AzureBlobAssetsModule.sln
+++ b/VirtoCommerce.AzureBlobAssetsModule.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29123.88
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4FD6A475-8E27-4933-A76F-38CD0A10663F}"
 EndProject

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -465,6 +465,7 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                 Name = fileName,
                 ContentType = contentType,
                 Size = props.ContentLength,
+                CreatedDate = props.CreatedOn.DateTime,
                 ModifiedDate = props.LastModified.DateTime,
                 RelativeUrl = relativeUrl
             };
@@ -483,6 +484,7 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                 Name = fileName,
                 ContentType = contentType,
                 Size = blob.Properties.ContentLength ?? 0,
+                CreatedDate = blob.Properties.CreatedOn.Value.DateTime,
                 ModifiedDate = blob.Properties.LastModified?.DateTime,
                 RelativeUrl = relativeUrl
             };

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -194,6 +194,8 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                         prefix += keyword;
                     }
 
+                    var containerProperties = await container.GetPropertiesAsync();
+
                     // Call the listing operation and return pages of the specified size.
                     var resultSegment = container.GetBlobsByHierarchyAsync(prefix: prefix, delimiter: Delimiter)
                         .AsPages();
@@ -216,6 +218,8 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                                 folder.Url = UrlHelperExtensions.Combine(baseUriEscaped, EscapeUri(blobhierarchyItem.Prefix));
                                 folder.ParentUrl = GetParentUrl(baseUriEscaped, blobhierarchyItem.Prefix);
                                 folder.RelativeUrl = folder.Url.Replace(EscapeUri(_blobServiceClient.Uri.ToString()), string.Empty);
+                                folder.CreatedDate = containerProperties.Value.LastModified.UtcDateTime;
+                                folder.ModifiedDate = containerProperties.Value.LastModified.UtcDateTime;
                                 result.Results.Add(folder);
                             }
                             else
@@ -465,8 +469,8 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                 Name = fileName,
                 ContentType = contentType,
                 Size = props.ContentLength,
-                CreatedDate = props.CreatedOn.DateTime,
-                ModifiedDate = props.LastModified.DateTime,
+                CreatedDate = props.CreatedOn.UtcDateTime,
+                ModifiedDate = props.LastModified.UtcDateTime,
                 RelativeUrl = relativeUrl
             };
         }
@@ -484,8 +488,8 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                 Name = fileName,
                 ContentType = contentType,
                 Size = blob.Properties.ContentLength ?? 0,
-                CreatedDate = blob.Properties.CreatedOn.Value.DateTime,
-                ModifiedDate = blob.Properties.LastModified?.DateTime,
+                CreatedDate = blob.Properties.CreatedOn.Value.UtcDateTime,
+                ModifiedDate = blob.Properties.LastModified?.UtcDateTime,
                 RelativeUrl = relativeUrl
             };
         }

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
@@ -16,7 +16,7 @@
   <iconUrl>Modules/$(VirtoCommerce.AzureBlobAssetsModule)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes />
-  <copyright>Copyright © 2021 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2022 Virto Commerce. All rights reserved</copyright>
   <tags>assets</tags>
   <assemblyFile>VirtoCommerce.AzureBlobAssetsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.AzureBlobAssetsModule.Web.Module, VirtoCommerce.AzureBlobAssetsModule.Web</moduleType>


### PR DESCRIPTION
## Description
fix: Empty Created and Modified Date for Assets and Folders

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-9091
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.202.0-pr-5-2153.zip
