### PR TITLE
PT-10674: Job not processing images that stores in folder with space in its name

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -159,7 +159,14 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
 
         protected static string NormalizeUrl(string blobUrl)
         {
-            return (new Uri(blobUrl)).AbsoluteUri;
+            try
+            {
+                return (new Uri(blobUrl)).AbsoluteUri;
+            }
+            catch (Exception)
+            {
+                return blobUrl;
+            }
         }
 
         public virtual async Task RemoveAsync(string[] urls)

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -112,6 +112,14 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
 
         public virtual async Task<Stream> OpenWriteAsync(string blobUrl)
         {
+            if (string.IsNullOrEmpty(blobUrl))
+            {
+                throw new ArgumentNullException(nameof(blobUrl));
+            }
+
+            // Normilize Url if blobUrl has wrong encoded, like contains space  
+            blobUrl = NormalizeUrl(blobUrl);
+
             var filePath = GetFilePathFromUrl(blobUrl);
             var fileName = Path.GetFileName(filePath);
 
@@ -149,12 +157,17 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
             return new FlushLessStream(await blob.OpenWriteAsync(true, options));
         }
 
+        protected static string NormalizeUrl(string blobUrl)
+        {
+            return (new Uri(blobUrl)).AbsoluteUri;
+        }
+
         public virtual async Task RemoveAsync(string[] urls)
         {
             foreach (var url in urls.Where(x => !string.IsNullOrWhiteSpace(x)))
             {
                 var absoluteUri = url.IsAbsoluteUrl()
-                    ? new Uri(url).ToString()
+                    ? url
                     : UrlHelperExtensions.Combine(_blobServiceClient.Uri.ToString(), url);
                 var blobContainer = GetBlobContainer(GetContainerNameFromUrl(absoluteUri));
 
@@ -217,11 +230,15 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                                    .Split(new[] { Delimiter }, StringSplitOptions.RemoveEmptyEntries)
                                    .Last();
 
-                                folder.Url = UrlHelperExtensions.Combine(baseUriEscaped, EscapeUri(blobhierarchyItem.Prefix));
+                                var folderUrlBuilder = new UriBuilder(new Uri(baseUriEscaped));
+                                folderUrlBuilder.Path += Delimiter + blobhierarchyItem.Prefix;
+                                folder.Url = folderUrlBuilder.ToString();
                                 folder.ParentUrl = GetParentUrl(baseUriEscaped, blobhierarchyItem.Prefix);
                                 folder.RelativeUrl = folder.Url.Replace(EscapeUri(_blobServiceClient.Uri.ToString()), string.Empty);
+
                                 folder.CreatedDate = containerProperties.Value.LastModified.UtcDateTime;
                                 folder.ModifiedDate = containerProperties.Value.LastModified.UtcDateTime;
+
                                 result.Results.Add(folder);
                             }
                             else
@@ -248,7 +265,11 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                     {
                         var folder = AbstractTypeFactory<BlobFolder>.TryCreateInstance();
                         folder.Name = item.Name.Split(Delimiter).Last();
-                        folder.Url = EscapeUri(UrlHelperExtensions.Combine(_blobServiceClient.Uri.ToString(), item.Name));
+
+                        var folderUrlBuilder = new UriBuilder(_blobServiceClient.Uri);
+                        folderUrlBuilder.Path += item.Name + Delimiter;
+                        folder.Url = folderUrlBuilder.ToString();
+
                         result.Results.Add(folder);
                     }
                 }
@@ -260,15 +281,20 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
 
         public virtual async Task CreateFolderAsync(BlobFolder folder)
         {
-            var path = folder.ParentUrl == null ?
-                        folder.Name :
-                        UrlHelperExtensions.Combine(folder.ParentUrl, folder.Name);
+            var newFolderUrl = folder.Name;
 
-            var containerName = GetContainerNameFromUrl(path);
+            if (folder.ParentUrl != null)
+            {
+                var newFolderUriBuilder = new UriBuilder(new Uri(folder.ParentUrl));
+                newFolderUriBuilder.Path += Delimiter + folder.Name;
+                newFolderUrl = newFolderUriBuilder.ToString();
+            }
+
+            var containerName = GetContainerNameFromUrl(newFolderUrl);
             var container = _blobServiceClient.GetBlobContainerClient(containerName);
             await container.CreateIfNotExistsAsync(PublicAccessType.Blob);
 
-            var directoryPath = GetDirectoryPathFromUrl(path);
+            var directoryPath = GetDirectoryPathFromUrl(newFolderUrl);
             if (!string.IsNullOrEmpty(directoryPath))
             {
                 // Need to upload an empty '.keep' blob because Azure Blob Storage does not support direct directory creation
@@ -406,6 +432,7 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         private string[] GetOutlineFromUrl(string url)
         {
             var relativeUrl = url;
+
             if (url.IsAbsoluteUrl())
             {
                 relativeUrl = Uri.UnescapeDataString(new Uri(url).AbsolutePath);
@@ -423,13 +450,13 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         private string GetDirectoryPathFromUrl(string url)
         {
             var result = string.Join(Delimiter, GetOutlineFromUrl(url).Skip(1).ToArray());
-            return !string.IsNullOrEmpty(result) ? result + Delimiter : null;
+            return !string.IsNullOrEmpty(result) ? Uri.UnescapeDataString(result) + Delimiter : null;
         }
 
         private string GetFilePathFromUrl(string url)
         {
             var result = string.Join(Delimiter, GetOutlineFromUrl(url).Skip(1).ToArray());
-            return !string.IsNullOrEmpty(result) ? result : null;
+            return !string.IsNullOrEmpty(result) ? Uri.UnescapeDataString(result) : null;
         }
 
         private string GetParentUrl(string baseUri, string blobPrefix)
@@ -483,9 +510,13 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
 
         private BlobInfo ConvertBlobToBlobInfo(BlobItem blob, string baseUri)
         {
-            var fileName = Path.GetFileName(blob.Name);
-            var absoluteUrl = UrlHelperExtensions.Combine(baseUri, EscapeUri(blob.Name));
+            var fileUrlBuilder = new UriBuilder(new Uri(baseUri));
+            fileUrlBuilder.Path = fileUrlBuilder.Path + "/" + blob.Name;
+            var absoluteUrl = fileUrlBuilder.ToString();
+
             var relativeUrl = absoluteUrl.Replace(EscapeUri(_blobServiceClient.Uri.ToString()), string.Empty);
+
+            var fileName = Path.GetFileName(blob.Name);
             var contentType = MimeTypeResolver.ResolveContentType(fileName);
 
             return new BlobInfo


### PR DESCRIPTION
## Description
fix: Job not processing images that stores in folder with space in its name. 
fix: Search, Read, Write and Delete if either folder or file name contains space or other encoded charecters.

## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-10674
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.209.0-pr-12-a839.zip
