### PR TITLE
feat: Add the ability to connect Azure blob storage with SAS

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -582,7 +582,15 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
             {
                 absoluteUri = new Uri(absoluteUri.GetLeftPart(UriPartial.Path));
             }
-            return _blobServiceClient.Uri.MakeRelativeUri(absoluteUri).ToString();
+            var result = _blobServiceClient.Uri.MakeRelativeUri(absoluteUri).ToString();
+
+            // Ensure the relative URL starts with a delimiter
+            if (!result.StartsWith(Delimiter))
+            {
+                result = Delimiter + result;
+            }
+
+            return result;
         }
 
         private static string GetAbsoluteUrl(Uri baseUri, string blobPrefix)

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
         <PackageReference Include="VirtoCommerce.Assets.Abstractions" Version="3.200.0" />
-        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.800.0" />
+        <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.801.0" />
         <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.800.0" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.1" />
     </ItemGroup>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
     <platformVersion>3.800.0</platformVersion>
     <dependencies>
-        <dependency id="VirtoCommerce.Assets" version="3.800.0" />
+        <dependency id="VirtoCommerce.Assets" version="3.801.0" />
     </dependencies>
 
     <title>Azure Blob Storage Assets Provider</title>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.800.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.802.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.803.0" />
   </dependencies>
 
   <title>Azure Blob Storage Assets Provider</title>

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
@@ -42,6 +42,7 @@ public class AppConfiguration
             .ReturnsAsync(new ObjectSettingEntry { AllowedValues = [] });
         var fileExtensionService = new FileExtensionService(platformOptions, settingsManager.Object);
 
-        return new AzureBlobProvider(options, fileExtensionService);
+
+        return new AzureBlobProvider(options, fileExtensionService, null);
     }
 }

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
@@ -10,12 +10,12 @@ namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
 
 public class AppConfiguration
 {
-    public static IConfigurationRoot Configuration;
+    private static IConfigurationRoot _configuration;
 
     public AppConfiguration()
     {
         // Build configuration
-        Configuration = new ConfigurationBuilder()
+        _configuration = new ConfigurationBuilder()
             .AddUserSecrets<AppConfiguration>()
             .Build();
     }
@@ -24,11 +24,11 @@ public class AppConfiguration
         where T : new()
     {
         var result = new T();
-        Configuration.GetSection("Assets:AzureBlobStorage").Bind(result);
+        _configuration.GetSection("Assets:AzureBlobStorage").Bind(result);
 
         return result;
     }
-        
+
     public static AzureBlobProvider GetAzureBlobProvider()
     {
         var options = Options.Create(new AppConfiguration().GetApplicationConfiguration<AzureBlobOptions>());
@@ -41,7 +41,7 @@ public class AppConfiguration
         settingsManager.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .ReturnsAsync(new ObjectSettingEntry { AllowedValues = [] });
         var fileExtensionService = new FileExtensionService(platformOptions, settingsManager.Object);
-            
+
         return new AzureBlobProvider(options, fileExtensionService);
     }
 }

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
@@ -1,26 +1,47 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.AssetsModule.Core.Services;
+using VirtoCommerce.AzureBlobAssetsModule.Core;
+using VirtoCommerce.Platform.Core;
+using VirtoCommerce.Platform.Core.Settings;
 
-namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests
+namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
+
+public class AppConfiguration
 {
-    public class AppConfiguration
+    public static IConfigurationRoot Configuration;
+
+    public AppConfiguration()
     {
-        public static IConfigurationRoot configuration;
+        // Build configuration
+        Configuration = new ConfigurationBuilder()
+            .AddUserSecrets<AppConfiguration>()
+            .Build();
+    }
 
-        public AppConfiguration()
+    public T GetApplicationConfiguration<T>()
+        where T : new()
+    {
+        var result = new T();
+        Configuration.GetSection("Assets:AzureBlobStorage").Bind(result);
+
+        return result;
+    }
+        
+    public static AzureBlobProvider GetAzureBlobProvider()
+    {
+        var options = Options.Create(new AppConfiguration().GetApplicationConfiguration<AzureBlobOptions>());
+        var platformOptions = Options.Create(new PlatformOptions
         {
-            // Build configuration
-            configuration = new ConfigurationBuilder()
-                .AddUserSecrets<AppConfiguration>()
-                .Build();
-        }
-
-        public T GetApplicationConfiguration<T>()
-            where T : new()
-        {
-            var result = new T();
-            configuration.GetSection("Assets:AzureBlobStorage").Bind(result);
-
-            return result;
-        }
+            FileExtensionsBlackList = [],
+            FileExtensionsWhiteList = [],
+        });
+        var settingsManager = new Mock<ISettingsManager>();
+        settingsManager.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new ObjectSettingEntry { AllowedValues = [] });
+        var fileExtensionService = new FileExtensionService(platformOptions, settingsManager.Object);
+            
+        return new AzureBlobProvider(options, fileExtensionService);
     }
 }

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
@@ -6,7 +6,7 @@ using VirtoCommerce.AzureBlobAssetsModule.Core;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Settings;
 
-namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
+namespace VirtoCommerce.AzureBlobAssetsModule.Tests;
 
 public class AppConfiguration
 {

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AppConfiguration.cs
@@ -3,8 +3,6 @@ using Microsoft.Extensions.Options;
 using Moq;
 using VirtoCommerce.AssetsModule.Core.Services;
 using VirtoCommerce.AzureBlobAssetsModule.Core;
-using VirtoCommerce.Platform.Core;
-using VirtoCommerce.Platform.Core.Settings;
 
 namespace VirtoCommerce.AzureBlobAssetsModule.Tests;
 
@@ -32,17 +30,12 @@ public class AppConfiguration
     public static AzureBlobProvider GetAzureBlobProvider()
     {
         var options = Options.Create(new AppConfiguration().GetApplicationConfiguration<AzureBlobOptions>());
-        var platformOptions = Options.Create(new PlatformOptions
-        {
-            FileExtensionsBlackList = [],
-            FileExtensionsWhiteList = [],
-        });
-        var settingsManager = new Mock<ISettingsManager>();
-        settingsManager.Setup(x => x.GetObjectSettingAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-            .ReturnsAsync(new ObjectSettingEntry { AllowedValues = [] });
-        var fileExtensionService = new FileExtensionService(platformOptions, settingsManager.Object);
 
+        var mockFileExtensionService = new Mock<IFileExtensionService>();
+        mockFileExtensionService
+            .Setup(service => service.IsExtensionAllowedAsync(It.IsAny<string>()))
+            .ReturnsAsync(true);
 
-        return new AzureBlobProvider(options, fileExtensionService, null);
+        return new AzureBlobProvider(options, mockFileExtensionService.Object, eventPublisher: null);
     }
 }

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
@@ -2,10 +2,11 @@ using System.IO;
 using System.Threading.Tasks;
 using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.AzureBlobAssetsModule.Core;
+using VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
 using VirtoCommerce.Platform.Core.Common;
 using Xunit;
 
-namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
+namespace VirtoCommerce.AzureBlobAssetsModule.Tests;
 
 [Trait("Category", "IntegrationTest")]
 [Collection("AzureBlobStorageProvider")]
@@ -145,7 +146,7 @@ public class AzureBlobStorageProviderIntegrationTests
             await writer.WriteAsync("""{"result":true}""");
         }
         var created = await _fixture.Provider.ExistsAsync(oldBlobUrl);
-        
+
         var copied = false;
         if (await _fixture.Provider.ExistsAsync(newBlobUrl))
         {
@@ -160,7 +161,7 @@ public class AzureBlobStorageProviderIntegrationTests
         // Assert
         Assert.True(created && copied);
     }
-        
+
     [Fact]
     public async Task Search_Should_ReturnNotEmptyCollection()
     {
@@ -173,7 +174,7 @@ public class AzureBlobStorageProviderIntegrationTests
         // Assert
         Assert.False(result?.Results.IsNullOrEmpty());
     }
-        
+
     [Fact]
     public async Task SearchContainers_Should_ReturnNotEmptyCollection()
     {
@@ -224,16 +225,16 @@ public class AzureBlobStorageProviderIntegrationTests
         Assert.True(created);
     }
 }
-    
+
 public class AzureBlobStorageProviderIntegrationTestSetup
 {
     public AzureBlobProvider Provider { get; }
-        
+
     public AzureBlobStorageProviderIntegrationTestSetup()
     {
         Provider = AppConfiguration.GetAzureBlobProvider();
     }
 }
-    
+
 [CollectionDefinition("AzureBlobStorageProvider")]
 public abstract class AzureBlobStorageProviderCollection : ICollectionFixture<AzureBlobStorageProviderIntegrationTestSetup>;

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
@@ -1,0 +1,239 @@
+using System.IO;
+using System.Threading.Tasks;
+using VirtoCommerce.AssetsModule.Core.Assets;
+using VirtoCommerce.AzureBlobAssetsModule.Core;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
+
+[Trait("Category", "IntegrationTest")]
+[Collection("AzureBlobStorageProvider")]
+public class AzureBlobStorageProviderIntegrationTests
+{
+    private readonly AzureBlobStorageProviderIntegrationTestSetup _fixture;
+    private const string ContainerName = "virtualsupplier";
+
+    public AzureBlobStorageProviderIntegrationTests(AzureBlobStorageProviderIntegrationTestSetup fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public void GetAbsoluteUrl_Should_ReturnUrl()
+    {
+        // Arrange
+        const string blobUrl = $"{ContainerName}/Catalog/result.json";
+
+        // Act
+        var uri = _fixture.Provider.GetAbsoluteUrl(blobUrl);
+
+        // Assert
+        Assert.NotEmpty(uri);
+        Assert.StartsWith("https", uri);
+    }
+
+    [Fact]
+    public async Task GetBlobInfo_Should_ReturnSameRelative()
+    {
+        // Arrange
+        const string blobUrl = $"{ContainerName}/Catalog/result.json";
+
+        // Act
+        var blobInfo = await _fixture.Provider.GetBlobInfoAsync(blobUrl);
+
+        // Assert
+        Assert.NotNull(blobInfo);
+        Assert.Equal(blobUrl, blobInfo.RelativeUrl, true);
+    }
+
+    [Fact]
+    public async Task OpenRead_Should_ReturnNotEmptyStream()
+    {
+        // Arrange
+        const string blobUrl = $"{ContainerName}/Catalog/result.json";
+
+        // Act
+        await using var stream = await _fixture.Provider.OpenReadAsync(blobUrl);
+
+        // Assert
+        Assert.True(stream.CanRead);
+        Assert.True(stream.Length > 0);
+    }
+
+    [Fact]
+    public async Task OpenWrite_Should_ReturnWritableStream()
+    {
+        // Arrange
+        const string blobUrl = $"{ContainerName}/Catalog/temp.json";
+
+        // Act
+        await using var stream = await _fixture.Provider.OpenWriteAsync(blobUrl);
+        await using var writer = new StreamWriter(stream);
+        await writer.WriteAsync("""{"result":true}""");
+
+        // Assert
+        Assert.True(stream.CanWrite);
+    }
+
+    [Fact]
+    public async Task Remove_Should_RemoveBlob()
+    {
+        // Arrange
+        const string blobUrl = $"{ContainerName}/Catalog/remove.json";
+
+        // Act
+        await using (var stream = await _fixture.Provider.OpenWriteAsync(blobUrl))
+        {
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync("""{"result":true}""");
+        }
+        var created = await _fixture.Provider.ExistsAsync(blobUrl);
+        var removed = false;
+
+        if (created)
+        {
+            await _fixture.Provider.RemoveAsync([blobUrl]);
+            removed = !await _fixture.Provider.ExistsAsync(blobUrl);
+        }
+
+        // Assert
+        Assert.True(created && removed);
+    }
+
+    [Fact]
+    public async Task Move_Should_MoveBlob()
+    {
+        // Arrange
+        const string oldBlobUrl = $"{ContainerName}/Catalog/move.json";
+        const string newBlobUrl = $"{ContainerName}/Catalog/MoveFolder/move.json";
+
+        // Act
+        await using (var stream = await _fixture.Provider.OpenWriteAsync(oldBlobUrl))
+        {
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync("""{"result":true}""");
+        }
+        var created = await _fixture.Provider.ExistsAsync(oldBlobUrl);
+
+        var moved = false;
+        if (await _fixture.Provider.ExistsAsync(newBlobUrl))
+        {
+            await _fixture.Provider.RemoveAsync([newBlobUrl]);
+        }
+        if (created)
+        {
+            await _fixture.Provider.MoveAsyncPublic(oldBlobUrl, newBlobUrl);
+            moved = !await _fixture.Provider.ExistsAsync(oldBlobUrl) && await _fixture.Provider.ExistsAsync(newBlobUrl);
+        }
+
+        // Assert
+        Assert.True(created && moved);
+    }
+
+    [Fact]
+    public async Task Copy_Should_CopyBlob()
+    {
+        // Arrange
+        const string oldBlobUrl = $"{ContainerName}/Catalog/copy.json";
+        const string newBlobUrl = $"{ContainerName}/Catalog/CopyFolder/copy.json";
+
+        // Act
+        await using (var stream = await _fixture.Provider.OpenWriteAsync(oldBlobUrl))
+        {
+            await using var writer = new StreamWriter(stream);
+            await writer.WriteAsync("""{"result":true}""");
+        }
+        var created = await _fixture.Provider.ExistsAsync(oldBlobUrl);
+        
+        var copied = false;
+        if (await _fixture.Provider.ExistsAsync(newBlobUrl))
+        {
+            await _fixture.Provider.RemoveAsync([newBlobUrl]);
+        }
+        if (created)
+        {
+            await _fixture.Provider.CopyAsync(oldBlobUrl, newBlobUrl);
+            copied = await _fixture.Provider.ExistsAsync(oldBlobUrl) && await _fixture.Provider.ExistsAsync(newBlobUrl);
+        }
+
+        // Assert
+        Assert.True(created && copied);
+    }
+        
+    [Fact]
+    public async Task Search_Should_ReturnNotEmptyCollection()
+    {
+        // Arrange
+        const string folderUrl = $"{ContainerName}/Catalog";
+
+        // Act
+        var result = await _fixture.Provider.SearchAsync(folderUrl, null);
+
+        // Assert
+        Assert.False(result?.Results.IsNullOrEmpty());
+    }
+        
+    [Fact]
+    public async Task SearchContainers_Should_ReturnNotEmptyCollection()
+    {
+        // Arrange
+        const string keyword = ContainerName;
+
+        // Act
+        var result = await _fixture.Provider.SearchAsync(null, keyword);
+
+        // Assert
+        Assert.False(result?.Results.IsNullOrEmpty());
+    }
+
+    [Fact]
+    public async Task CreateFolder_Should_CreateWithoutParent()
+    {
+        // Arrange
+        const string folderUrl = $"{ContainerName}/Catalog/NewFolder";
+        var folder = new BlobFolder
+        {
+            Name = folderUrl,
+        };
+
+        // Act
+        await _fixture.Provider.CreateFolderAsync(folder);
+        var created = await _fixture.Provider.ExistsAsync(folderUrl);
+
+        // Assert
+        Assert.True(created);
+    }
+
+    [Fact]
+    public async Task CreateFolder_Should_CreateWithParent()
+    {
+        // Arrange
+        const string folderUrl = $"{ContainerName}/Catalog/SubFolder";
+        var folder = new BlobFolder
+        {
+            Name = "SubFolder",
+            ParentUrl = $"{ContainerName}/Catalog",
+        };
+
+        // Act
+        await _fixture.Provider.CreateFolderAsync(folder);
+        var created = await _fixture.Provider.ExistsAsync(folderUrl);
+
+        // Assert
+        Assert.True(created);
+    }
+}
+    
+public class AzureBlobStorageProviderIntegrationTestSetup
+{
+    public AzureBlobProvider Provider { get; }
+        
+    public AzureBlobStorageProviderIntegrationTestSetup()
+    {
+        Provider = AppConfiguration.GetAzureBlobProvider();
+    }
+}
+    
+[CollectionDefinition("AzureBlobStorageProvider")]
+public abstract class AzureBlobStorageProviderCollection : ICollectionFixture<AzureBlobStorageProviderIntegrationTestSetup>;

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
@@ -227,12 +227,7 @@ public class AzureBlobStorageProviderIntegrationTests
 
 public class AzureBlobStorageProviderIntegrationTestSetup
 {
-    public AzureBlobProvider Provider { get; }
-
-    public AzureBlobStorageProviderIntegrationTestSetup()
-    {
-        Provider = AppConfiguration.GetAzureBlobProvider();
-    }
+    public AzureBlobProvider Provider { get; } = AppConfiguration.GetAzureBlobProvider();
 }
 
 [CollectionDefinition("AzureBlobStorageProvider")]

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
@@ -23,7 +23,7 @@ public class AzureBlobStorageProviderIntegrationTests
     public void GetAbsoluteUrl_Should_ReturnUrl()
     {
         // Arrange
-        const string blobUrl = $"{ContainerName}/Catalog/result.json";
+        const string blobUrl = $"/{ContainerName}/Catalog/result.json";
 
         // Act
         var uri = _fixture.Provider.GetAbsoluteUrl(blobUrl);
@@ -37,7 +37,7 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task GetBlobInfo_Should_ReturnSameRelative()
     {
         // Arrange
-        const string blobUrl = $"{ContainerName}/Catalog/result.json";
+        const string blobUrl = $"/{ContainerName}/Catalog/result.json";
 
         // Act
         var blobInfo = await _fixture.Provider.GetBlobInfoAsync(blobUrl);
@@ -51,7 +51,7 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task OpenRead_Should_ReturnNotEmptyStream()
     {
         // Arrange
-        const string blobUrl = $"{ContainerName}/Catalog/result.json";
+        const string blobUrl = $"/{ContainerName}/Catalog/result.json";
 
         // Act
         await using var stream = await _fixture.Provider.OpenReadAsync(blobUrl);
@@ -65,7 +65,7 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task OpenWrite_Should_ReturnWritableStream()
     {
         // Arrange
-        const string blobUrl = $"{ContainerName}/Catalog/temp.json";
+        const string blobUrl = $"/{ContainerName}/Catalog/temp.json";
 
         // Act
         await using var stream = await _fixture.Provider.OpenWriteAsync(blobUrl);
@@ -80,7 +80,7 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task Remove_Should_RemoveBlob()
     {
         // Arrange
-        const string blobUrl = $"{ContainerName}/Catalog/remove.json";
+        const string blobUrl = $"/{ContainerName}/Catalog/remove.json";
 
         // Act
         await using (var stream = await _fixture.Provider.OpenWriteAsync(blobUrl))
@@ -105,8 +105,8 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task Move_Should_MoveBlob()
     {
         // Arrange
-        const string oldBlobUrl = $"{ContainerName}/Catalog/move.json";
-        const string newBlobUrl = $"{ContainerName}/Catalog/MoveFolder/move.json";
+        const string oldBlobUrl = $"/{ContainerName}/Catalog/move.json";
+        const string newBlobUrl = $"/{ContainerName}/Catalog/MoveFolder/move.json";
 
         // Act
         await using (var stream = await _fixture.Provider.OpenWriteAsync(oldBlobUrl))
@@ -135,8 +135,8 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task Copy_Should_CopyBlob()
     {
         // Arrange
-        const string oldBlobUrl = $"{ContainerName}/Catalog/copy.json";
-        const string newBlobUrl = $"{ContainerName}/Catalog/CopyFolder/copy.json";
+        const string oldBlobUrl = $"/{ContainerName}/Catalog/copy.json";
+        const string newBlobUrl = $"/{ContainerName}/Catalog/CopyFolder/copy.json";
 
         // Act
         await using (var stream = await _fixture.Provider.OpenWriteAsync(oldBlobUrl))
@@ -165,7 +165,7 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task Search_Should_ReturnNotEmptyCollection()
     {
         // Arrange
-        const string folderUrl = $"{ContainerName}/Catalog";
+        const string folderUrl = $"/{ContainerName}/Catalog";
 
         // Act
         var result = await _fixture.Provider.SearchAsync(folderUrl, null);
@@ -191,7 +191,7 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task CreateFolder_Should_CreateWithoutParent()
     {
         // Arrange
-        const string folderUrl = $"{ContainerName}/Catalog/NewFolder";
+        const string folderUrl = $"/{ContainerName}/Catalog/NewFolder";
         var folder = new BlobFolder
         {
             Name = folderUrl,
@@ -209,11 +209,11 @@ public class AzureBlobStorageProviderIntegrationTests
     public async Task CreateFolder_Should_CreateWithParent()
     {
         // Arrange
-        const string folderUrl = $"{ContainerName}/Catalog/SubFolder";
+        const string folderUrl = $"/{ContainerName}/Catalog/SubFolder";
         var folder = new BlobFolder
         {
             Name = "SubFolder",
-            ParentUrl = $"{ContainerName}/Catalog",
+            ParentUrl = $"/{ContainerName}/Catalog",
         };
 
         // Act

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
@@ -2,7 +2,6 @@ using System.IO;
 using System.Threading.Tasks;
 using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.AzureBlobAssetsModule.Core;
-using VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
 using VirtoCommerce.Platform.Core.Common;
 using Xunit;
 

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
@@ -2,78 +2,68 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using System.Linq;
 using VirtoCommerce.AzureBlobAssetsModule.Core;
-using VirtoCommerce.Platform.Core;
 using Xunit;
 
-namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests
+namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
+
+public class AzureBlobStorageProviderTests
 {
-    public class AzureBlobStorageProviderTests
+    /// <summary>
+    /// `OpenWrite` method should return write-only stream.
+    /// </summary>
+    /// <remarks>
+    /// Broken -> https://github.com/VirtoCommerce/vc-platform/pull/2254/checks?check_run_id=2551785684
+    /// </remarks>
+    [Fact(Skip = "Test is broken on CI")]
+    public void StreamWritePermissionsTest()
     {
-        private readonly IOptions<AzureBlobOptions> _options;
+        // Arrange
+        var provider = AppConfiguration.GetAzureBlobProvider();
+        const string fileUrl = "tmpfolder/file-write.tmp";
 
-        public AzureBlobStorageProviderTests()
-        {
-            _options = new OptionsWrapper<AzureBlobOptions>(new AppConfiguration().GetApplicationConfiguration<AzureBlobOptions>());
-        }
+        // Act
+        using var actualStream = provider.OpenWrite(fileUrl);
 
-        /// <summary>
-        /// `OpenWrite` method should return write-only stream.
-        /// </summary>
-        /// <remarks>
-        /// Broken -> https://github.com/VirtoCommerce/vc-platform/pull/2254/checks?check_run_id=2551785684
-        /// </remarks>
-        [Fact(Skip = "Test is broken on CI")]
-        public void StreamWritePermissionsTest()
-        {
-            // Arrange
-            var provider = new AzureBlobProvider(_options, new OptionsWrapper<PlatformOptions>(new PlatformOptions()), null);
-            var fileName = "file-write.tmp";
-            var fileUrl = $"tmpfolder/{fileName}";
+        // Assert
+        Assert.True(actualStream.CanWrite, "'OpenWrite' stream should be writable.");
+        Assert.False(actualStream.CanRead, "'OpenWrite' stream should be write-only.");
+        Assert.Equal(0, actualStream.Position);
+    }
 
-            // Act
-            using var actualStream = provider.OpenWrite(fileUrl);
-
-            // Assert
-            Assert.True(actualStream.CanWrite, "'OpenWrite' stream should be writable.");
-            Assert.False(actualStream.CanRead, "'OpenWrite' stream should be write-only.");
-            Assert.Equal(0, actualStream.Position);
-        }
-
-        [Fact]
-        public void AzureBlobOptions_CanValidateDataAnnotations()
-        {
-            //Arrange
-            var services = new ServiceCollection();
-            services.AddOptions<AzureBlobOptions>()
-                .Configure(o =>
-                {
-                    o.ConnectionString = null;
-                })
-                .ValidateDataAnnotations();
-
-            //Act
-            var sp = services.BuildServiceProvider();
-
-            //Assert
-            var error = Assert.Throws<OptionsValidationException>(() => sp.GetRequiredService<IOptions<AzureBlobOptions>>().Value);
-            ValidateFailure<AzureBlobOptions>(error, Options.DefaultName, 1,
-                $"DataAnnotation validation failed for '{nameof(AzureBlobOptions)}' members: '{nameof(AzureBlobOptions.ConnectionString)}' with the error: 'The {nameof(AzureBlobOptions.ConnectionString)} field is required.'.");
-        }
-
-        private void ValidateFailure<TOptions>(OptionsValidationException ex, string name = "", int count = 1, params string[] errorsToMatch)
-        {
-            Assert.Equal(typeof(TOptions), ex.OptionsType);
-            Assert.Equal(name, ex.OptionsName);
-            if (errorsToMatch.Length == 0)
+    [Fact]
+    public void AzureBlobOptions_CanValidateDataAnnotations()
+    {
+        //Arrange
+        var services = new ServiceCollection();
+        services.AddOptions<AzureBlobOptions>()
+            .Configure(o =>
             {
-                errorsToMatch = new string[] { "A validation error has occured." };
-            }
-            Assert.Equal(count, ex.Failures.Count());
-            // Check for the error in any of the failures
-            foreach (var error in errorsToMatch)
-            {
-                Assert.True(ex.Failures.FirstOrDefault(f => f.Contains(error)) != null, "Did not find: " + error);
-            }
+                o.ConnectionString = null;
+            })
+            .ValidateDataAnnotations();
+
+        //Act
+        var sp = services.BuildServiceProvider();
+
+        //Assert
+        var error = Assert.Throws<OptionsValidationException>(() => sp.GetRequiredService<IOptions<AzureBlobOptions>>().Value);
+        ValidateFailure<AzureBlobOptions>(error, Options.DefaultName, 1,
+            $"DataAnnotation validation failed for '{nameof(AzureBlobOptions)}' members: '{nameof(AzureBlobOptions.ConnectionString)}' with the error: 'The {nameof(AzureBlobOptions.ConnectionString)} field is required.'.");
+    }
+
+    private static void ValidateFailure<TOptions>(OptionsValidationException ex, string name = "", int count = 1, params string[] errorsToMatch)
+    {
+        Assert.Equal(typeof(TOptions), ex.OptionsType);
+        Assert.Equal(name, ex.OptionsName);
+        if (errorsToMatch.Length == 0)
+        {
+            errorsToMatch = ["A validation error has occured."];
+        }
+        Assert.Equal(count, ex.Failures.Count());
+        // Check for the error in any of the failures
+        foreach (var error in errorsToMatch)
+        {
+            Assert.True(ex.Failures.FirstOrDefault(f => f.Contains(error)) != null, "Did not find: " + error);
         }
     }
 }

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
@@ -1,8 +1,6 @@
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Moq;
-using VirtoCommerce.AssetsModule.Core.Services;
 using VirtoCommerce.AzureBlobAssetsModule.Core;
 using Xunit;
 

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
@@ -1,10 +1,10 @@
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using System.Linq;
 using VirtoCommerce.AzureBlobAssetsModule.Core;
 using Xunit;
 
-namespace VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests;
+namespace VirtoCommerce.AzureBlobAssetsModule.Tests;
 
 public class AzureBlobStorageProviderTests
 {


### PR DESCRIPTION
## Description

- Add the ability to connect Azure blob storage with shared access signatures (SAS)
- Refactor getting absolute and relative URI
## References
https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-an-azure-storage-account
https://learn.microsoft.com/en-us/rest/api/storageservices/create-account-sas
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.803.0-pr-20-5a5c.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.802.0-pr-20-673c.zip