### PR TITLE
VCST-1385: External link encoded after saving

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -614,7 +614,10 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
 
         private static Uri GetAbsoluteUri(Uri baseUri, string inputUrl)
         {
-            if (Uri.TryCreate(inputUrl, UriKind.Absolute, out var resultUri))
+            ArgumentNullException.ThrowIfNull(nameof(inputUrl));
+
+            // do trim lead slash to prevent transform it to absolute file path on linux.
+            if (Uri.TryCreate(inputUrl.TrimStart('/'), UriKind.Absolute, out var resultUri))
             {
                 // If the input URL is already absolute, return it as is (with correct encoding)
                 return resultUri;


### PR DESCRIPTION
## Description
fix: Resolves issue with External link encoded after saving

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1385
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.805.0-pr-23-6d6f.zip