### PR TITLE
VCST-1527: Incorrect absolute urls resolved by Azure blob assets module

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -612,9 +612,15 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
             return result;
         }
 
-        private static Uri GetAbsoluteUri(Uri baseUri, string inputUrl)
+        public static Uri GetAbsoluteUri(Uri baseUri, string inputUrl)
         {
             ArgumentNullException.ThrowIfNull(nameof(inputUrl));
+
+            // base uri should be end with delimiter. see tests
+            if (!baseUri.AbsolutePath.EndsWith(Delimiter))
+            {
+                baseUri = new Uri(baseUri.AbsoluteUri + Delimiter);
+            }
 
             // do trim lead slash to prevent transform it to absolute file path on linux.
             if (Uri.TryCreate(inputUrl.TrimStart('/'), UriKind.Absolute, out var resultUri))

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -128,6 +129,18 @@ public class AzureBlobStorageProviderTests
         var blobUrlResolver = (IBlobUrlResolver)provider;
 
         Assert.Equal(absoluteUrl, blobUrlResolver.GetAbsoluteUrl(blobKey));
+    }
+
+    [Theory]
+    [InlineData("https://qademovc3.core.windows.net/cms", "Themes/", "https://qademovc3.core.windows.net/cms/Themes/")]
+    [InlineData("https://qademovc3.core.windows.net/cms/", "Themes", "https://qademovc3.core.windows.net/cms/Themes")]
+    [InlineData("https://qademovc3.core.windows.net/cms/", "/Themes/", "https://qademovc3.core.windows.net/cms/Themes/")]
+    [InlineData("https://qademovc3.core.windows.net/cms", "/Themes", "https://qademovc3.core.windows.net/cms/Themes")]
+    [InlineData("https://qademovc3.core.windows.net/", "Themes/", "https://qademovc3.core.windows.net/Themes/")]
+    [InlineData("https://qademovc3.core.windows.net", "Themes/", "https://qademovc3.core.windows.net/Themes/")]
+    public void GetAbsoluteUri_StaticMethod(string baseUrl, string inputUrl, string absoluteUrl)
+    {
+        Assert.Equal(absoluteUrl, AzureBlobProvider.GetAbsoluteUri(new Uri(baseUrl), inputUrl).AbsoluteUri);
     }
 
 


### PR DESCRIPTION
## Description
fix: Incorrect absolute urls resolved by Azure blob assets module

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1527
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.806.0-pr-24-8427.zip