### PR TITLE
fix: Restore ability to connect Azure blob storage with SAS

### DIFF
--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
@@ -143,6 +143,14 @@ public class AzureBlobStorageProviderTests
         Assert.Equal(absoluteUrl, AzureBlobProvider.GetAbsoluteUri(new Uri(baseUrl), inputUrl).AbsoluteUri);
     }
 
+    [Theory]
+    [InlineData("https://qademovc3.core.windows.net/cms/test?sv=2022-11-02&ss=b&srt=co&sp", "Catalog/", "https://qademovc3.core.windows.net/cms/test/Catalog/?sv=2022-11-02&ss=b&srt=co&sp")]
+    [InlineData("https://qademovc3.core.windows.net/cms/test?sv=2022-11-02&ss=b&srt=co&sp", "/Catalog", "https://qademovc3.core.windows.net/cms/test/Catalog?sv=2022-11-02&ss=b&srt=co&sp")]
+    [InlineData("https://qademovc3.core.windows.net/cms/test?sv=2022-11-02&ss=b&srt=co&sp", "/Catalog/", "https://qademovc3.core.windows.net/cms/test/Catalog/?sv=2022-11-02&ss=b&srt=co&sp")]
+    public void GetAbsoluteUriWithParameters_StaticMethod(string baseUrl, string inputUrl, string absoluteUrl)
+    {
+        Assert.Equal(absoluteUrl, AzureBlobProvider.GetAbsoluteUri(new Uri(baseUrl), inputUrl).AbsoluteUri);
+    }
 
     private static void ValidateFailure<TOptions>(OptionsValidationException ex, string name = "", int count = 1, params string[] errorsToMatch)
     {


### PR DESCRIPTION
## Description
- Restore ability to connect Azure blob storage with SAS
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.807.0-pr-25-9ad8.zip