### PR TITLE
Fixed bug deleting all blobs with matching prefix

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -185,14 +185,20 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                 }
                 else
                 {
-                    var blobItems = container.GetBlobsAsync(prefix: blobSearchPrefix);
-                    await foreach (var blobItem in blobItems)
+                    if (isFolder)
                     {
-                        if (blobItem.Name != blobSearchPrefix)
+                        // Delete all blobs with the prefix (folder)
+                        var blobItems = container.GetBlobsAsync(prefix: blobSearchPrefix);
+                        await foreach (var blobItem in blobItems)
                         {
-                            continue;
+                            var blobClient = container.GetBlobClient(blobItem.Name);
+                            await blobClient.DeleteIfExistsAsync();
                         }
-                        var blobClient = container.GetBlobClient(blobItem.Name);
+                    }
+                    else
+                    {
+                        // Delete only the exact file
+                        var blobClient = container.GetBlobClient(blobSearchPrefix);
                         await blobClient.DeleteIfExistsAsync();
                     }
                 }


### PR DESCRIPTION
Fixed bug deleting all blobs with matching prefix

## Description
The previous implementation deleted all files beginning with the provided target name, which caused unintended deletions. In the content module, this led to both `.md` and `.md-draft` files being removed when only the `.md` file was meant to be deleted before renaming `.md-draft` to `.md`.

## References
### QA-test:
### Jira-link:
### Artifact URL:
