### PR TITLE
VCST-4203: Remove obsolete code

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
@@ -15,8 +15,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.814.0-alpha.161-vcst-4203-cleanup" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.814.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2,9)" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
@@ -15,8 +15,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.808.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.853.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.814.0-alpha.161-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2,9)" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.812.0</version>
   <version-tag />
 
-  <platformVersion>3.853.0</platformVersion>
+  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.808.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.814.0-alpha.161-vcst-4203-cleanup" />
   </dependencies>
 
   <title>Azure Blob Storage Assets Provider</title>
@@ -21,7 +21,7 @@
   <iconUrl>Modules/$(VirtoCommerce.AzureBlobAssetsModule)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes />
-  <copyright>Copyright © 2024 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2024-2025 Virto Commerce. All rights reserved</copyright>
   <tags>assets</tags>
   <assemblyFile>VirtoCommerce.AzureBlobAssetsModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.AzureBlobAssetsModule.Web.Module, VirtoCommerce.AzureBlobAssetsModule.Web</moduleType>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.812.0</version>
   <version-tag />
 
-  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
+  <platformVersion>3.917.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.814.0-alpha.161-vcst-4203-cleanup" />
+    <dependency id="VirtoCommerce.Assets" version="3.814.0" />
   </dependencies>
 
   <title>Azure Blob Storage Assets Provider</title>

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/VirtoCommerce.AzureBlobAssetsModule.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/VirtoCommerce.AzureBlobAssetsModule.Tests.csproj
@@ -13,7 +13,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Required modules list URL:
https://github.com/VirtoCommerce/vc-modules/raw/refs/heads/VCST-4203-cleanup/update/modules.json
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4203
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.812.0-pr-32-179a.zip