### PR TITLE
VCST-4697: Update Azure.Storage.Blobs to 12.27.0

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
@@ -13,9 +13,9 @@
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.25.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1008.0-alpha.13209-vcst-4697-azurecore" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/VirtoCommerce.AzureBlobAssetsModule.Core.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1008.0-alpha.13209-vcst-4697-azurecore" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1010.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.3" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1001.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1008.0-alpha.13209-vcst-4697-azurecore</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
   </dependencies>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/module.manifest
@@ -4,7 +4,7 @@
   <version>3.1001.0</version>
   <version-tag />
 
-  <platformVersion>3.1008.0-alpha.13209-vcst-4697-azurecore</platformVersion>
+  <platformVersion>3.1010.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
   </dependencies>


### PR DESCRIPTION
## Description
feat: Update Azure.Storage.Blobs to 12.27.0

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4697
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.1001.0-pr-34-2812.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency upgrades can introduce subtle behavior/regression changes in blob storage operations and require running on Platform `3.1010.0`.
> 
> **Overview**
> Upgrades `Azure.Storage.Blobs` from `12.25.1` to `12.27.0` in `VirtoCommerce.AzureBlobAssetsModule.Core`.
> 
> Bumps `VirtoCommerce.Platform.Core` and the module `platformVersion` requirement from `3.1002.0` to `3.1010.0` to align with the newer platform dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2812b61fa4c420877ccc9f199f7f959020645c87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->