### PR TITLE
Getting the SAS link

### DIFF
--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -430,15 +430,15 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
 
         public string GenerateSasUrl(string blobUrl, TimeSpan expiresIn)
         {
-            var blob = GetBlockBlobClient(blobUrl);
+            var blobName = GetFilePathFromUrl(blobUrl);
             var containerName = GetContainerNameFromUrl(blobUrl);
             var blobClient = GetBlobContainerClient(blobUrl)
-                .GetBlobClient(blob.Name);
+                .GetBlobClient(blobName);
 
             var sasBuilder = new BlobSasBuilder
             {
                 BlobContainerName = containerName,
-                BlobName = blob.Name,
+                BlobName = blobName,
                 Resource = "b",
                 ExpiresOn = DateTimeOffset.UtcNow.Add(expiresIn)
             };

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -8,6 +8,7 @@ using System.Web;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
+using Azure.Storage.Sas;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Assets.Abstractions;
 using VirtoCommerce.AssetsModule.Core.Assets;
@@ -22,7 +23,7 @@ using BlobInfo = VirtoCommerce.AssetsModule.Core.Assets.BlobInfo;
 
 namespace VirtoCommerce.AzureBlobAssetsModule.Core
 {
-    public class AzureBlobProvider : IBlobStorageProvider, IBlobUrlResolver, ICommonBlobProvider
+    public class AzureBlobProvider : IBlobStorageProvider, IBlobUrlResolver, ICommonBlobProvider, IAzureBlobUrlResolver
     {
         public const string ProviderName = "AzureBlobStorage";
         public const string BlobCacheControlPropertyValue = "public, max-age=604800";
@@ -424,6 +425,30 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         }
 
         #endregion IBlobUrlResolver Members
+
+        #region IAzureBlobUrlResolver Members
+
+        public string GenerateSasUrl(string blobUrl, TimeSpan expiresIn)
+        {
+            var blob = GetBlockBlobClient(blobUrl);
+            var containerName = GetContainerNameFromUrl(blobUrl);
+            var blobClient = GetBlobContainerClient(blobUrl)
+                .GetBlobClient(blob.Name);
+
+            var sasBuilder = new BlobSasBuilder
+            {
+                BlobContainerName = containerName,
+                BlobName = blob.Name,
+                Resource = "b",
+                ExpiresOn = DateTimeOffset.UtcNow.Add(expiresIn)
+            };
+
+            sasBuilder.SetPermissions(BlobSasPermissions.Read);
+
+            return blobClient.GenerateSasUri(sasBuilder).ToString();
+        }
+
+        #endregion
 
         protected virtual BlobInfo ConvertToBlobInfo(BlobBaseClient blob, BlobProperties props, IDictionary<string, string> tags)
         {

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-using Microsoft.Extensions.DependencyInjection;
 using System;
+using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.Assets.Abstractions;
 using VirtoCommerce.AssetsModule.Core.Assets;
 
@@ -12,6 +12,7 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core.Extensions
             services.AddSingleton<ICommonBlobProvider, AzureBlobProvider>();
             services.AddSingleton<IBlobStorageProvider, AzureBlobProvider>();
             services.AddSingleton<IBlobUrlResolver, AzureBlobProvider>();
+            services.AddSingleton<IAzureBlobUrlResolver, AzureBlobProvider>();
             if (setupAction != null)
             {
                 services.Configure(setupAction);

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/IAzureBlobUrlResolver.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/IAzureBlobUrlResolver.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace VirtoCommerce.AzureBlobAssetsModule.Core;
+
+public interface IAzureBlobUrlResolver
+{
+    string GenerateSasUrl(string blobUrl, TimeSpan expiresIn);
+}

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using VirtoCommerce.AssetsModule.Core.Assets;
@@ -9,15 +10,9 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Tests;
 
 [Trait("Category", "IntegrationTest")]
 [Collection("AzureBlobStorageProvider")]
-public class AzureBlobStorageProviderIntegrationTests
+public class AzureBlobStorageProviderIntegrationTests(AzureBlobStorageProviderIntegrationTestSetup fixture)
 {
-    private readonly AzureBlobStorageProviderIntegrationTestSetup _fixture;
     private const string ContainerName = "virtualsupplier";
-
-    public AzureBlobStorageProviderIntegrationTests(AzureBlobStorageProviderIntegrationTestSetup fixture)
-    {
-        _fixture = fixture;
-    }
 
     [Fact]
     public void GetAbsoluteUrl_Should_ReturnUrl()
@@ -26,7 +21,7 @@ public class AzureBlobStorageProviderIntegrationTests
         const string blobUrl = $"/{ContainerName}/Catalog/result.json";
 
         // Act
-        var uri = _fixture.Provider.GetAbsoluteUrl(blobUrl);
+        var uri = fixture.Provider.GetAbsoluteUrl(blobUrl);
 
         // Assert
         Assert.NotEmpty(uri);
@@ -40,7 +35,7 @@ public class AzureBlobStorageProviderIntegrationTests
         const string blobUrl = $"/{ContainerName}/Catalog/result.json";
 
         // Act
-        var blobInfo = await _fixture.Provider.GetBlobInfoAsync(blobUrl);
+        var blobInfo = await fixture.Provider.GetBlobInfoAsync(blobUrl);
 
         // Assert
         Assert.NotNull(blobInfo);
@@ -54,7 +49,7 @@ public class AzureBlobStorageProviderIntegrationTests
         const string blobUrl = $"/{ContainerName}/Catalog/result.json";
 
         // Act
-        await using var stream = await _fixture.Provider.OpenReadAsync(blobUrl);
+        await using var stream = await fixture.Provider.OpenReadAsync(blobUrl);
 
         // Assert
         Assert.True(stream.CanRead);
@@ -68,7 +63,7 @@ public class AzureBlobStorageProviderIntegrationTests
         const string blobUrl = $"/{ContainerName}/Catalog/temp.json";
 
         // Act
-        await using var stream = await _fixture.Provider.OpenWriteAsync(blobUrl);
+        await using var stream = await fixture.Provider.OpenWriteAsync(blobUrl);
         await using var writer = new StreamWriter(stream);
         await writer.WriteAsync("""{"result":true}""");
 
@@ -83,18 +78,18 @@ public class AzureBlobStorageProviderIntegrationTests
         const string blobUrl = $"/{ContainerName}/Catalog/remove.json";
 
         // Act
-        await using (var stream = await _fixture.Provider.OpenWriteAsync(blobUrl))
+        await using (var stream = await fixture.Provider.OpenWriteAsync(blobUrl))
         {
             await using var writer = new StreamWriter(stream);
             await writer.WriteAsync("""{"result":true}""");
         }
-        var created = await _fixture.Provider.ExistsAsync(blobUrl);
+        var created = await fixture.Provider.ExistsAsync(blobUrl);
         var removed = false;
 
         if (created)
         {
-            await _fixture.Provider.RemoveAsync([blobUrl]);
-            removed = !await _fixture.Provider.ExistsAsync(blobUrl);
+            await fixture.Provider.RemoveAsync([blobUrl]);
+            removed = !await fixture.Provider.ExistsAsync(blobUrl);
         }
 
         // Assert
@@ -109,22 +104,22 @@ public class AzureBlobStorageProviderIntegrationTests
         const string newBlobUrl = $"/{ContainerName}/Catalog/MoveFolder/move.json";
 
         // Act
-        await using (var stream = await _fixture.Provider.OpenWriteAsync(oldBlobUrl))
+        await using (var stream = await fixture.Provider.OpenWriteAsync(oldBlobUrl))
         {
             await using var writer = new StreamWriter(stream);
             await writer.WriteAsync("""{"result":true}""");
         }
-        var created = await _fixture.Provider.ExistsAsync(oldBlobUrl);
+        var created = await fixture.Provider.ExistsAsync(oldBlobUrl);
 
         var moved = false;
-        if (await _fixture.Provider.ExistsAsync(newBlobUrl))
+        if (await fixture.Provider.ExistsAsync(newBlobUrl))
         {
-            await _fixture.Provider.RemoveAsync([newBlobUrl]);
+            await fixture.Provider.RemoveAsync([newBlobUrl]);
         }
         if (created)
         {
-            await _fixture.Provider.MoveAsyncPublic(oldBlobUrl, newBlobUrl);
-            moved = !await _fixture.Provider.ExistsAsync(oldBlobUrl) && await _fixture.Provider.ExistsAsync(newBlobUrl);
+            await fixture.Provider.MoveAsyncPublic(oldBlobUrl, newBlobUrl);
+            moved = !await fixture.Provider.ExistsAsync(oldBlobUrl) && await fixture.Provider.ExistsAsync(newBlobUrl);
         }
 
         // Assert
@@ -139,22 +134,22 @@ public class AzureBlobStorageProviderIntegrationTests
         const string newBlobUrl = $"/{ContainerName}/Catalog/CopyFolder/copy.json";
 
         // Act
-        await using (var stream = await _fixture.Provider.OpenWriteAsync(oldBlobUrl))
+        await using (var stream = await fixture.Provider.OpenWriteAsync(oldBlobUrl))
         {
             await using var writer = new StreamWriter(stream);
             await writer.WriteAsync("""{"result":true}""");
         }
-        var created = await _fixture.Provider.ExistsAsync(oldBlobUrl);
+        var created = await fixture.Provider.ExistsAsync(oldBlobUrl);
 
         var copied = false;
-        if (await _fixture.Provider.ExistsAsync(newBlobUrl))
+        if (await fixture.Provider.ExistsAsync(newBlobUrl))
         {
-            await _fixture.Provider.RemoveAsync([newBlobUrl]);
+            await fixture.Provider.RemoveAsync([newBlobUrl]);
         }
         if (created)
         {
-            await _fixture.Provider.CopyAsync(oldBlobUrl, newBlobUrl);
-            copied = await _fixture.Provider.ExistsAsync(oldBlobUrl) && await _fixture.Provider.ExistsAsync(newBlobUrl);
+            await fixture.Provider.CopyAsync(oldBlobUrl, newBlobUrl);
+            copied = await fixture.Provider.ExistsAsync(oldBlobUrl) && await fixture.Provider.ExistsAsync(newBlobUrl);
         }
 
         // Assert
@@ -168,7 +163,7 @@ public class AzureBlobStorageProviderIntegrationTests
         const string folderUrl = $"/{ContainerName}/Catalog";
 
         // Act
-        var result = await _fixture.Provider.SearchAsync(folderUrl, null);
+        var result = await fixture.Provider.SearchAsync(folderUrl, null);
 
         // Assert
         Assert.False(result?.Results.IsNullOrEmpty());
@@ -181,7 +176,7 @@ public class AzureBlobStorageProviderIntegrationTests
         const string keyword = ContainerName;
 
         // Act
-        var result = await _fixture.Provider.SearchAsync(null, keyword);
+        var result = await fixture.Provider.SearchAsync(null, keyword);
 
         // Assert
         Assert.False(result?.Results.IsNullOrEmpty());
@@ -198,8 +193,8 @@ public class AzureBlobStorageProviderIntegrationTests
         };
 
         // Act
-        await _fixture.Provider.CreateFolderAsync(folder);
-        var created = await _fixture.Provider.ExistsAsync(folderUrl);
+        await fixture.Provider.CreateFolderAsync(folder);
+        var created = await fixture.Provider.ExistsAsync(folderUrl);
 
         // Assert
         Assert.True(created);
@@ -217,11 +212,25 @@ public class AzureBlobStorageProviderIntegrationTests
         };
 
         // Act
-        await _fixture.Provider.CreateFolderAsync(folder);
-        var created = await _fixture.Provider.ExistsAsync(folderUrl);
+        await fixture.Provider.CreateFolderAsync(folder);
+        var created = await fixture.Provider.ExistsAsync(folderUrl);
 
         // Assert
         Assert.True(created);
+    }
+
+    [Fact]
+    public void GenerateSasUrl_Should_ReturnUrl()
+    {
+        // Arrange
+        const string blobUrl = $"/{ContainerName}/Catalog/result.json";
+
+        // Act
+        var uri = fixture.Provider.GenerateSasUrl(blobUrl, TimeSpan.FromMinutes(1));
+
+        // Assert
+        Assert.NotEmpty(uri);
+        Assert.StartsWith("https", uri);
     }
 }
 


### PR DESCRIPTION
## Description
Getting the SAS link for files

## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.1002.0-pr-35-cb1a.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces SAS URL generation (security-sensitive) that controls temporary access to blobs; incorrect expiry/permissions or misuse could expose assets unintentionally.
> 
> **Overview**
> Adds `IAzureBlobUrlResolver` and extends `AzureBlobProvider` to generate **read-only, time-limited SAS links** via `GenerateSasUrl(blobUrl, expiresIn)` using `BlobSasBuilder`.
> 
> Registers the new resolver in `AddAzureBlobProvider` DI setup, and updates integration tests to use primary constructor injection plus a new test covering SAS URL generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb1a086ba570d2d589324a27dea6767651a7e14b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->