### PR TITLE
VCST-4890: CDN-aware URLs in Azure Blob Storage provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Azure Blob Storage Assets module provides integration with [Azure Blob Stora
         "Provider": "AzureBlobStorage",
         "AzureBlobStorage": {
             "ConnectionString": "",
-            "CdnUrl": "",
+            "PublicUrl": "",
             "AllowBlobPublicAccess": true
         }
     }
@@ -19,8 +19,13 @@ The Azure Blob Storage Assets module provides integration with [Azure Blob Stora
 3. Modify the following settings:
     - Set the **Provider** value to **AzureBlobStorage**.
     - Provide **ConnectionString** in case you are going to use the **AzureBlobStorage** implementation option.
-    - Set up "CdnUrl": "" if you want to configured CDN before Azure Blob Storage. By default, empty. Ex: `https://cdn.somecloud.com`.
+    - Set up **PublicUrl** to expose blobs through a CDN or custom public endpoint instead of the direct Azure Blob URL. Applies to both admin and storefront responses (search results, blob info, copy, download). By default, empty — direct blob URLs are returned. Accepts:
+        - bare host: `cdn.somecloud.com`
+        - full URL: `https://cdn.somecloud.com`
+        - full URL with sub-path: `https://cdn.somecloud.com/static`
     - Set up **AllowBlobPublicAccess** to `false`, if create private container by default. By default, `true`.
+
+> **Note:** The legacy **CdnUrl** setting is still supported as an alias of **PublicUrl** — existing configurations keep working without changes. New deployments should use **PublicUrl**.
 
 
 ## Documentation

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobOptions.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace VirtoCommerce.AzureBlobAssetsModule.Core
@@ -8,9 +9,21 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         public string ConnectionString { get; set; }
 
         /// <summary>
-        /// Url of the CDN server
+        /// Public URL used to expose blobs to clients (admin UI, storefront).
+        /// Accepts a bare host (cdn.example.com), a full URL (https://cdn.example.com),
+        /// or a full URL with a sub-path (https://cdn.example.com/static).
         /// </summary>
-        public string CdnUrl { get; set; }
+        public string PublicUrl { get; set; }
+
+        /// <summary>
+        /// Url of the CDN server. Alias of <see cref="PublicUrl"/> kept for backward compatibility.
+        /// </summary>
+        [Obsolete("Use PublicUrl instead. CdnUrl is kept as an alias for backward compatibility.")]
+        public string CdnUrl
+        {
+            get => PublicUrl;
+            set => PublicUrl = value;
+        }
 
         /// <summary>
         /// If true, create new blob containers with access type PublicAccessType.Blob

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobOptions.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobOptions.cs
@@ -18,11 +18,23 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         /// <summary>
         /// Url of the CDN server. Alias of <see cref="PublicUrl"/> kept for backward compatibility.
         /// </summary>
+        /// <remarks>
+        /// The setter ignores null or whitespace-only values so that an accidental
+        /// CdnUrl=null assignment (e.g. when the configuration binder iterates this
+        /// alias property after PublicUrl has already been bound) cannot clear a
+        /// value that was set through PublicUrl.
+        /// </remarks>
         [Obsolete("Use PublicUrl instead. CdnUrl is kept as an alias for backward compatibility.")]
         public string CdnUrl
         {
             get => PublicUrl;
-            set => PublicUrl = value;
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    PublicUrl = value;
+                }
+            }
         }
 
         /// <summary>

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -9,6 +9,8 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Assets.Abstractions;
 using VirtoCommerce.AssetsModule.Core.Assets;
@@ -33,17 +35,35 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         private readonly bool _allowBlobPublicAccess;
         private readonly IFileExtensionService _fileExtensionService;
         private readonly IEventPublisher _eventPublisher;
+        private readonly ILogger<AzureBlobProvider> _logger;
 
         public AzureBlobProvider(
             IOptions<AzureBlobOptions> options,
             IFileExtensionService fileExtensionService,
             IEventPublisher eventPublisher)
+            : this(options, fileExtensionService, eventPublisher, NullLogger<AzureBlobProvider>.Instance)
+        {
+        }
+
+        public AzureBlobProvider(
+            IOptions<AzureBlobOptions> options,
+            IFileExtensionService fileExtensionService,
+            IEventPublisher eventPublisher,
+            ILogger<AzureBlobProvider> logger)
         {
             _blobServiceClient = new BlobServiceClient(options.Value.ConnectionString);
+            _logger = logger ?? NullLogger<AzureBlobProvider>.Instance;
             _publicBaseUri = NormalizePublicUrl(options.Value.PublicUrl, _blobServiceClient.Uri.Scheme);
             _allowBlobPublicAccess = options.Value.AllowBlobPublicAccess;
             _fileExtensionService = fileExtensionService;
             _eventPublisher = eventPublisher;
+
+            _logger.LogInformation(
+                "AzureBlobProvider initialized. BlobServiceUri='{BlobServiceUri}', PublicUrlConfigured='{PublicUrlValue}', PublicBaseUri='{PublicBaseUri}', AllowBlobPublicAccess={AllowBlobPublicAccess}",
+                _blobServiceClient.Uri,
+                string.IsNullOrWhiteSpace(options.Value.PublicUrl) ? "(empty)" : options.Value.PublicUrl,
+                _publicBaseUri?.ToString() ?? "(null - falls back to blob service Uri)",
+                _allowBlobPublicAccess);
         }
 
         private static Uri NormalizePublicUrl(string publicUrl, string defaultScheme)
@@ -257,6 +277,13 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                 {
                     var internalBaseUri = container.Uri; // absoluteUri is escaped already
                     var publicBaseUri = GetAbsoluteUri(GetPublicBaseUri(), container.Name + Delimiter);
+                    _logger.LogDebug(
+                        "SearchAsync: folderUrl='{FolderUrl}', container='{Container}', internalBaseUri='{InternalBaseUri}', publicBaseUri='{PublicBaseUri}', publicUrlConfigured={PublicUrlConfigured}",
+                        folderUrl,
+                        container.Name,
+                        internalBaseUri,
+                        publicBaseUri,
+                        _publicBaseUri != null);
                     var prefix = GetDirectoryPathFromUrl(folderUrl);
                     if (!string.IsNullOrEmpty(keyword))
                     {

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Core/AzureBlobProvider.cs
@@ -29,7 +29,7 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         public const string BlobCacheControlPropertyValue = "public, max-age=604800";
         private const string Delimiter = "/";
         private readonly BlobServiceClient _blobServiceClient;
-        private readonly string _cdnUrl;
+        private readonly Uri _publicBaseUri;
         private readonly bool _allowBlobPublicAccess;
         private readonly IFileExtensionService _fileExtensionService;
         private readonly IEventPublisher _eventPublisher;
@@ -40,11 +40,29 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
             IEventPublisher eventPublisher)
         {
             _blobServiceClient = new BlobServiceClient(options.Value.ConnectionString);
-            _cdnUrl = options.Value.CdnUrl;
+            _publicBaseUri = NormalizePublicUrl(options.Value.PublicUrl, _blobServiceClient.Uri.Scheme);
             _allowBlobPublicAccess = options.Value.AllowBlobPublicAccess;
             _fileExtensionService = fileExtensionService;
             _eventPublisher = eventPublisher;
         }
+
+        private static Uri NormalizePublicUrl(string publicUrl, string defaultScheme)
+        {
+            if (string.IsNullOrWhiteSpace(publicUrl))
+            {
+                return null;
+            }
+
+            if (publicUrl.Contains("://", StringComparison.Ordinal)
+                && Uri.TryCreate(publicUrl, UriKind.Absolute, out var absolute))
+            {
+                return absolute;
+            }
+
+            return new UriBuilder(defaultScheme, publicUrl).Uri;
+        }
+
+        private Uri GetPublicBaseUri() => _publicBaseUri ?? _blobServiceClient.Uri;
 
         #region ICommonBlobProvider members
 
@@ -237,7 +255,8 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
 
                 if (await container.ExistsAsync())
                 {
-                    var baseUri = container.Uri; // absoluteUri is escaped already
+                    var internalBaseUri = container.Uri; // absoluteUri is escaped already
+                    var publicBaseUri = GetAbsoluteUri(GetPublicBaseUri(), container.Name + Delimiter);
                     var prefix = GetDirectoryPathFromUrl(folderUrl);
                     if (!string.IsNullOrEmpty(keyword))
                     {
@@ -258,12 +277,12 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
                         {
                             if (blobHierarchyItem.IsPrefix)
                             {
-                                var folder = ConvertToBlobFolder(blobHierarchyItem, baseUri, containerProperties.Value);
+                                var folder = ConvertToBlobFolder(blobHierarchyItem, publicBaseUri, internalBaseUri, containerProperties.Value);
                                 result.Results.Add(folder);
                             }
                             else
                             {
-                                var blobInfo = ConvertToBlobInfo(blobHierarchyItem.Blob, baseUri);
+                                var blobInfo = ConvertToBlobInfo(blobHierarchyItem.Blob, publicBaseUri, internalBaseUri);
                                 //Do not return empty blob (created with directory because azure blob not support direct directory creation)
                                 if (!string.IsNullOrEmpty(blobInfo.Name))
                                 {
@@ -414,14 +433,7 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         {
             ArgumentNullException.ThrowIfNull(inputUrl);
 
-            var baseUri = _blobServiceClient.Uri;
-            if (!string.IsNullOrWhiteSpace(_cdnUrl))
-            {
-                var cdnUriBuilder = new UriBuilder(_blobServiceClient.Uri.Scheme, _cdnUrl);
-                baseUri = cdnUriBuilder.Uri;
-            }
-
-            return GetAbsoluteUri(baseUri, inputUrl).AbsoluteUri;
+            return GetAbsoluteUri(GetPublicBaseUri(), inputUrl).AbsoluteUri;
         }
 
         #endregion IBlobUrlResolver Members
@@ -454,11 +466,11 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         {
             var blobInfo = AbstractTypeFactory<BlobInfo>.TryCreateInstance();
 
-            var absoluteUri = blob.Uri;
-            var relativeUrl = GetRelativeUrl(absoluteUri);
+            var relativeUrl = GetRelativeUrl(blob.Uri);
+            var publicUri = GetAbsoluteUri(GetPublicBaseUri(), relativeUrl);
             var fileName = Path.GetFileName(Uri.UnescapeDataString(blob.Name));
 
-            blobInfo.Url = absoluteUri.AbsoluteUri;
+            blobInfo.Url = publicUri.AbsoluteUri;
             blobInfo.RelativeUrl = relativeUrl;
             blobInfo.Name = fileName;
             blobInfo.ContentType = props.ContentType.EmptyToNull() ?? MimeTypeResolver.ResolveContentType(fileName);
@@ -469,16 +481,22 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
             return blobInfo;
         }
 
+        [Obsolete("Use ConvertToBlobInfo(BlobItem, Uri publicBaseUri, Uri internalBaseUri) overload.")]
         protected virtual BlobInfo ConvertToBlobInfo(BlobItem blob, Uri baseUri)
+        {
+            return ConvertToBlobInfo(blob, baseUri, baseUri);
+        }
+
+        protected virtual BlobInfo ConvertToBlobInfo(BlobItem blob, Uri publicBaseUri, Uri internalBaseUri)
         {
             var blobInfo = AbstractTypeFactory<BlobInfo>.TryCreateInstance();
 
-            var absoluteUri = GetAbsoluteUri(baseUri, blob.Name);
-            var relativeUrl = GetRelativeUrl(absoluteUri);
+            var publicAbsoluteUri = GetAbsoluteUri(publicBaseUri, blob.Name);
+            var internalAbsoluteUri = GetAbsoluteUri(internalBaseUri, blob.Name);
             var fileName = Path.GetFileName(Uri.UnescapeDataString(blob.Name));
 
-            blobInfo.Url = absoluteUri.AbsoluteUri;
-            blobInfo.RelativeUrl = relativeUrl;
+            blobInfo.Url = publicAbsoluteUri.AbsoluteUri;
+            blobInfo.RelativeUrl = GetRelativeUrl(internalAbsoluteUri);
             blobInfo.Name = fileName;
             blobInfo.ContentType = blob.Properties.ContentType.EmptyToNull() ?? MimeTypeResolver.ResolveContentType(fileName);
             blobInfo.Size = blob.Properties.ContentLength ?? 0;
@@ -488,16 +506,27 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
             return blobInfo;
         }
 
+        [Obsolete("Use ConvertToBlobFolder(BlobHierarchyItem, Uri publicBaseUri, Uri internalBaseUri, BlobContainerProperties) overload.")]
         protected virtual BlobFolder ConvertToBlobFolder(BlobHierarchyItem blobHierarchyItem, Uri baseUri, BlobContainerProperties containerProperties)
+        {
+            return ConvertToBlobFolder(blobHierarchyItem, baseUri, baseUri, containerProperties);
+        }
+
+        protected virtual BlobFolder ConvertToBlobFolder(
+            BlobHierarchyItem blobHierarchyItem,
+            Uri publicBaseUri,
+            Uri internalBaseUri,
+            BlobContainerProperties containerProperties)
         {
             var folder = AbstractTypeFactory<BlobFolder>.TryCreateInstance();
 
-            var absoluteUri = GetAbsoluteUri(baseUri, blobHierarchyItem.Prefix);
+            var publicAbsoluteUri = GetAbsoluteUri(publicBaseUri, blobHierarchyItem.Prefix);
+            var internalAbsoluteUri = GetAbsoluteUri(internalBaseUri, blobHierarchyItem.Prefix);
 
             folder.Name = GetOutlineFromUrl(blobHierarchyItem.Prefix).Last();
-            folder.Url = absoluteUri.AbsoluteUri;
-            folder.ParentUrl = GetParentUrl(baseUri, blobHierarchyItem.Prefix);
-            folder.RelativeUrl = GetRelativeUrl(absoluteUri);
+            folder.Url = publicAbsoluteUri.AbsoluteUri;
+            folder.ParentUrl = GetParentUrl(publicBaseUri, blobHierarchyItem.Prefix);
+            folder.RelativeUrl = GetRelativeUrl(internalAbsoluteUri);
             folder.ModifiedDate = folder.CreatedDate = containerProperties.LastModified.UtcDateTime;
 
             return folder;
@@ -507,12 +536,12 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Core
         {
             var folder = AbstractTypeFactory<BlobFolder>.TryCreateInstance();
 
-            var baseUri = _blobServiceClient.Uri;
-            var absoluteUri = GetAbsoluteUri(baseUri, container.Name);
+            var publicAbsoluteUri = GetAbsoluteUri(GetPublicBaseUri(), container.Name);
+            var internalAbsoluteUri = GetAbsoluteUri(_blobServiceClient.Uri, container.Name);
 
             folder.Name = container.Name.Split(Delimiter).Last();
-            folder.Url = absoluteUri.AbsoluteUri;
-            folder.RelativeUrl = GetRelativeUrl(absoluteUri);
+            folder.Url = publicAbsoluteUri.AbsoluteUri;
+            folder.RelativeUrl = GetRelativeUrl(internalAbsoluteUri);
             folder.ModifiedDate = folder.CreatedDate = container.Properties.LastModified.UtcDateTime;
 
             return folder;

--- a/src/VirtoCommerce.AzureBlobAssetsModule.Web/Module.cs
+++ b/src/VirtoCommerce.AzureBlobAssetsModule.Web/Module.cs
@@ -23,7 +23,6 @@ namespace VirtoCommerce.AzureBlobAssetsModule.Web
                 serviceCollection.AddOptions<AzureBlobOptions>().Bind(Configuration.GetSection("Assets:AzureBlobStorage")).ValidateDataAnnotations();
                 serviceCollection.AddAzureBlobProvider();
             }
-
         }
 
         public void PostInitialize(IApplicationBuilder appBuilder)

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
@@ -211,6 +211,23 @@ public class AzureBlobStorageProviderTests
 #pragma warning restore CS0618
     }
 
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AzureBlobOptions_CdnUrlSetter_DoesNotClearPublicUrl_WhenValueIsNullOrEmpty(string emptyValue)
+    {
+        // Guards against the configuration binder calling CdnUrl=null after PublicUrl
+        // has been bound (which would otherwise silently wipe out PublicUrl).
+        var options = new AzureBlobOptions { PublicUrl = "https://cdn.example.com" };
+
+#pragma warning disable CS0618 // exercising the obsolete alias intentionally
+        options.CdnUrl = emptyValue;
+#pragma warning restore CS0618
+
+        Assert.Equal("https://cdn.example.com", options.PublicUrl);
+    }
+
     [Fact]
     public void LegacyCdnUrlConfig_StillRoutedThroughPublicUrl()
     {

--- a/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
+++ b/tests/VirtoCommerce.Platform.Assets.AzureBlobStorage.Tests/AzureBlobStorageProviderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -7,6 +8,7 @@ using VirtoCommerce.AssetsModule.Core.Assets;
 using VirtoCommerce.AssetsModule.Core.Services;
 using VirtoCommerce.AzureBlobAssetsModule.Core;
 using Xunit;
+using BlobInfo = VirtoCommerce.AssetsModule.Core.Assets.BlobInfo;
 
 namespace VirtoCommerce.AzureBlobAssetsModule.Tests;
 
@@ -75,12 +77,14 @@ public class AzureBlobStorageProviderTests
     [InlineData("https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space", "https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space")]
     public void GetAbsoluteUrlTest(string blobKey, string absoluteUrl)
     {
+#pragma warning disable CS0618 // legacy test exercises the CdnUrl alias intentionally
         var options = new AzureBlobOptions
         {
             ConnectionString = "DefaultEndpointsProtocol=https;AccountName=qademovc3;AccountKey=;EndpointSuffix=core.windows.net",
             CdnUrl = "",
             AllowBlobPublicAccess = true,
         };
+#pragma warning restore CS0618
 
         var mockFileExtensionService = new Mock<IFileExtensionService>();
         mockFileExtensionService
@@ -113,12 +117,14 @@ public class AzureBlobStorageProviderTests
     [InlineData("https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space", "https://localhost:5001/assets/catalog/151349/epson%20printer.txt?test=Name%20With%20Space")]
     public void GetAbsoluteUrlTestWithCdn(string blobKey, string absoluteUrl)
     {
+#pragma warning disable CS0618 // legacy test exercises the CdnUrl alias intentionally
         var options = new AzureBlobOptions
         {
             ConnectionString = "DefaultEndpointsProtocol=https;AccountName=qademovc3;AccountKey=;EndpointSuffix=core.windows.net",
             CdnUrl = "cdn.mydomain.com",
             AllowBlobPublicAccess = true,
         };
+#pragma warning restore CS0618
 
         var mockFileExtensionService = new Mock<IFileExtensionService>();
         mockFileExtensionService
@@ -150,6 +156,187 @@ public class AzureBlobStorageProviderTests
     public void GetAbsoluteUriWithParameters_StaticMethod(string baseUrl, string inputUrl, string absoluteUrl)
     {
         Assert.Equal(absoluteUrl, AzureBlobProvider.GetAbsoluteUri(new Uri(baseUrl), inputUrl).AbsoluteUri);
+    }
+
+    [Theory]
+    [InlineData("catalog/151349/epsonprinter.txt", "https://cdn.mydomain.com/catalog/151349/epsonprinter.txt")]
+    [InlineData("catalog/151349/epson printer.txt", "https://cdn.mydomain.com/catalog/151349/epson%20printer.txt")]
+    [InlineData("/catalog/151349/epsonprinter.txt", "https://cdn.mydomain.com/catalog/151349/epsonprinter.txt")]
+    [InlineData("epsonprinter.txt", "https://cdn.mydomain.com/epsonprinter.txt")]
+    public void GetAbsoluteUrlTestWithPublicUrl(string blobKey, string absoluteUrl)
+    {
+        // PublicUrl as bare host — should behave identically to legacy CdnUrl bare-host case
+        var provider = CreateProvider(publicUrl: "cdn.mydomain.com");
+        var blobUrlResolver = (IBlobUrlResolver)provider;
+
+        Assert.Equal(absoluteUrl, blobUrlResolver.GetAbsoluteUrl(blobKey));
+    }
+
+    [Theory]
+    [InlineData("catalog/151349/epsonprinter.txt", "https://cdn.mydomain.com/catalog/151349/epsonprinter.txt")]
+    [InlineData("catalog/151349/epson printer.txt", "https://cdn.mydomain.com/catalog/151349/epson%20printer.txt")]
+    [InlineData("/catalog/151349/epsonprinter.txt", "https://cdn.mydomain.com/catalog/151349/epsonprinter.txt")]
+    [InlineData("epsonprinter.txt", "https://cdn.mydomain.com/epsonprinter.txt")]
+    public void GetAbsoluteUrlTestWithPublicUrlFullUrl(string blobKey, string absoluteUrl)
+    {
+        // PublicUrl supplied as a full URL with scheme — must produce the same output as bare host
+        var provider = CreateProvider(publicUrl: "https://cdn.mydomain.com");
+        var blobUrlResolver = (IBlobUrlResolver)provider;
+
+        Assert.Equal(absoluteUrl, blobUrlResolver.GetAbsoluteUrl(blobKey));
+    }
+
+    [Theory]
+    [InlineData("catalog/151349/epsonprinter.txt", "https://cdn.mydomain.com/static/catalog/151349/epsonprinter.txt")]
+    [InlineData("catalog/151349/epson printer.txt", "https://cdn.mydomain.com/static/catalog/151349/epson%20printer.txt")]
+    [InlineData("/catalog/151349/epsonprinter.txt", "https://cdn.mydomain.com/static/catalog/151349/epsonprinter.txt")]
+    public void GetAbsoluteUrlTestWithPublicUrlAndPath(string blobKey, string absoluteUrl)
+    {
+        // PublicUrl with a sub-path — must be preserved as a prefix
+        var provider = CreateProvider(publicUrl: "https://cdn.mydomain.com/static");
+        var blobUrlResolver = (IBlobUrlResolver)provider;
+
+        Assert.Equal(absoluteUrl, blobUrlResolver.GetAbsoluteUrl(blobKey));
+    }
+
+    [Fact]
+    public void AzureBlobOptions_CdnUrlAliasesPublicUrl()
+    {
+#pragma warning disable CS0618 // exercising the obsolete alias intentionally
+        var fromCdn = new AzureBlobOptions { CdnUrl = "x.example.com" };
+        Assert.Equal("x.example.com", fromCdn.PublicUrl);
+
+        var fromPublic = new AzureBlobOptions { PublicUrl = "y.example.com" };
+        Assert.Equal("y.example.com", fromPublic.CdnUrl);
+#pragma warning restore CS0618
+    }
+
+    [Fact]
+    public void LegacyCdnUrlConfig_StillRoutedThroughPublicUrl()
+    {
+        // Configs that still use the legacy CdnUrl key must keep working.
+#pragma warning disable CS0618
+        var options = new AzureBlobOptions
+        {
+            ConnectionString = "DefaultEndpointsProtocol=https;AccountName=qademovc3;AccountKey=;EndpointSuffix=core.windows.net",
+            CdnUrl = "https://legacy.example.com",
+            AllowBlobPublicAccess = true,
+        };
+#pragma warning restore CS0618
+
+        var provider = CreateProvider(options: options);
+        var url = ((IBlobUrlResolver)provider).GetAbsoluteUrl("file.txt");
+
+        Assert.Equal("https://legacy.example.com/file.txt", url);
+    }
+
+    [Fact]
+    public void ConvertToBlobInfo_UsesPublicUrl_WhenConfigured()
+    {
+        var provider = new TestableAzureBlobProvider(publicUrl: "https://cdn.example.com");
+        var publicBaseUri = new Uri("https://cdn.example.com/catalog/");
+        var internalBaseUri = new Uri("https://qademovc3.blob.core.windows.net/catalog/");
+
+        var blobItem = BlobsModelFactory.BlobItem(
+            name: "folder/file.txt",
+            deleted: false,
+            properties: BlobsModelFactory.BlobItemProperties(
+                accessTierInferred: false,
+                contentType: "text/plain",
+                contentLength: 123,
+                createdOn: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                lastModified: new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero)));
+
+        var blobInfo = provider.InvokeConvertToBlobInfo(blobItem, publicBaseUri, internalBaseUri);
+
+        Assert.Equal("https://cdn.example.com/catalog/folder/file.txt", blobInfo.Url);
+        Assert.DoesNotContain("cdn.example.com", blobInfo.RelativeUrl);
+        Assert.StartsWith("/", blobInfo.RelativeUrl);
+    }
+
+    [Fact]
+    public void ConvertToBlobInfo_FallsBackToBlobUri_WhenPublicUrlEmpty()
+    {
+        var provider = new TestableAzureBlobProvider(publicUrl: null);
+        var blobServiceUri = new Uri("https://qademovc3.blob.core.windows.net/catalog/");
+
+        var blobItem = BlobsModelFactory.BlobItem(
+            name: "folder/file.txt",
+            deleted: false,
+            properties: BlobsModelFactory.BlobItemProperties(
+                accessTierInferred: false,
+                contentType: "text/plain",
+                contentLength: 123,
+                createdOn: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                lastModified: new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero)));
+
+        var blobInfo = provider.InvokeConvertToBlobInfo(blobItem, blobServiceUri, blobServiceUri);
+
+        Assert.StartsWith("https://qademovc3.blob.core.windows.net/", blobInfo.Url);
+    }
+
+    [Fact]
+    public void ConvertToBlobFolder_TopLevelContainer_UsesPublicUrl()
+    {
+        var provider = new TestableAzureBlobProvider(publicUrl: "https://cdn.example.com");
+
+        var container = BlobsModelFactory.BlobContainerItem(
+            name: "catalog",
+            properties: BlobsModelFactory.BlobContainerProperties(
+                lastModified: new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                eTag: new Azure.ETag("etag")));
+
+        var folder = provider.InvokeConvertToBlobFolder(container);
+
+        Assert.StartsWith("https://cdn.example.com/catalog", folder.Url);
+        Assert.DoesNotContain("cdn.example.com", folder.RelativeUrl);
+    }
+
+    private static AzureBlobProvider CreateProvider(string publicUrl = "", AzureBlobOptions options = null)
+    {
+        options ??= new AzureBlobOptions
+        {
+            ConnectionString = "DefaultEndpointsProtocol=https;AccountName=qademovc3;AccountKey=;EndpointSuffix=core.windows.net",
+            PublicUrl = publicUrl,
+            AllowBlobPublicAccess = true,
+        };
+
+        var mockFileExtensionService = new Mock<IFileExtensionService>();
+        mockFileExtensionService
+            .Setup(service => service.IsExtensionAllowedAsync(It.IsAny<string>()))
+            .ReturnsAsync(true);
+
+        return new AzureBlobProvider(Options.Create(options), mockFileExtensionService.Object, eventPublisher: null);
+    }
+
+    private sealed class TestableAzureBlobProvider : AzureBlobProvider
+    {
+        public TestableAzureBlobProvider(string publicUrl)
+            : base(Options.Create(new AzureBlobOptions
+            {
+                ConnectionString = "DefaultEndpointsProtocol=https;AccountName=qademovc3;AccountKey=;EndpointSuffix=core.windows.net",
+                PublicUrl = publicUrl,
+                AllowBlobPublicAccess = true,
+            }), CreateFileExtensionService(), eventPublisher: null)
+        {
+        }
+
+        public BlobInfo InvokeConvertToBlobInfo(BlobItem blob, Uri publicBaseUri, Uri internalBaseUri)
+        {
+            return ConvertToBlobInfo(blob, publicBaseUri, internalBaseUri);
+        }
+
+        public BlobFolder InvokeConvertToBlobFolder(BlobContainerItem container)
+        {
+            return ConvertToBlobFolder(container);
+        }
+
+        private static IFileExtensionService CreateFileExtensionService()
+        {
+            var mock = new Mock<IFileExtensionService>();
+            mock.Setup(s => s.IsExtensionAllowedAsync(It.IsAny<string>())).ReturnsAsync(true);
+            return mock.Object;
+        }
     }
 
     private static void ValidateFailure<TOptions>(OptionsValidationException ex, string name = "", int count = 1, params string[] errorsToMatch)


### PR DESCRIPTION
## Description
fix: CDN-aware URLs in Azure Blob Storage provider

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4890
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AzureBlobAssets_3.1003.0-pr-36-ed61.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how blob and folder URLs are generated/returned (including search results and blob info), which can impact client-facing links if misconfigured; backward compatibility is maintained via the `CdnUrl` alias.
> 
> **Overview**
> Adds a new `AzureBlobOptions.PublicUrl` setting to generate **CDN/custom public** blob URLs, while keeping legacy `CdnUrl` as an `[Obsolete]` alias that won’t accidentally overwrite `PublicUrl` during config binding.
> 
> Updates `AzureBlobProvider` to normalize and use the configured public base URI when producing URLs (`GetAbsoluteUrl`, `SearchAsync` results, `ConvertToBlobInfo`/`ConvertToBlobFolder`), while keeping relative URLs derived from the internal blob service URI; also adds provider initialization/debug logging.
> 
> Expands tests to cover `PublicUrl` formats (bare host, full URL, sub-path), legacy `CdnUrl` compatibility, and the public-vs-internal URL mapping behavior; updates README to document `PublicUrl` and the `CdnUrl` deprecation/aliasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed61eeab20cd462c527fb1a76b8cb6683ee8689f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->